### PR TITLE
Fix missing node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/usr/src/rails-app
+      - /usr/src/rails-app/node_modules/  # use docker image's node_modules
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
When running with a shared volume between the host and the container, we need to make sure we don't override the container's node_modules that were set up with `yarn install`.