### PR TITLE
Mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Rails Starter Template Application
+
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
+
 This is a Ruby on Rails template using GOV.UK Design System styles: https://design-system.service.gov.uk/get-started/
 
 ## Setting up the app in development


### PR DESCRIPTION
Update README.md to mark repo as archived

As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.